### PR TITLE
Mention correct production build command in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The `-t` option monitors the source code for changes and will trigger incrementa
 To produce production web assets that you can deploy to any webserver, run 
 
 ```bash
-./gradlew jsBrowserProductionWebpack
+./gradlew jsBrowserDistribution
 ```
 
 This compiles everything and then packs everything up with webpack. All the assets in src/jsMain/resources are copied to the root along with the compiled source code in javascript form and an `index.html` file. All the styling is done using [tailwind CSS](https://tailwindcss.com/).


### PR DESCRIPTION
I noticed that the `jsBrowserProductionWebpack` command does not seem to produce the `build/dist/js/productionExecutable` folder that the `README` mentions. While investigating this issue, I noticed that the `publish.sh` script actually uses the `jsBrowserDistribution` command instead. This command produces the expected folder. This leads me to believe that the `README` is simply referencing the wrong command, and this commit corrects this discrepancy.